### PR TITLE
Use override for Gtk3::Widget::{set,get,add}_events

### DIFF
--- a/gtk3/reference-manual/custom-drawing/example-3.pl
+++ b/gtk3/reference-manual/custom-drawing/example-3.pl
@@ -135,9 +135,9 @@ sub activate() {
 	# Ask to receive events the drawing area doesn't normally
 	# subscribe to. In particular, we need to ask for the
 	# button press and motion notify events that want to handle.
-	$drawing_area->add_events(
-		${ Gtk3::Gdk::EventMask->new([ qw/button-press-mask pointer-motion-mask/ ]) }
-	);
+	$drawing_area->set_events(
+		  $drawing_area->get_events
+		| [ qw/button-press-mask pointer-motion-mask/ ] );
 
 	$window->show_all;
 }


### PR DESCRIPTION
Since those method signatures use `gint` rather that `GdkEventMask`, the
introspection is not able to use them as `Glib::Flags` of type
`Gtk3::Gdk::EventMask`.

Therefore, we need to use overrides to patch this. This requires using
the changes:

- Glib-Object-Introspection <https://git.gnome.org/browse/perl-Glib-Object-Introspection/commit/?id=15c0b5122fbcf588625b4f3c2c9135e78b7f321a>.
- Gtk3 <https://git.gnome.org/browse/perl-Gtk3/commit/?id=0ab5735649260695b55a6b7b788da8007f7eadd8>.

See discussion at <https://mail.gnome.org/archives/gtk-perl-list/2017-April/msg00001.html>,
<https://mail.gnome.org/archives/gtk-perl-list/2017-May/msg00001.html>.

Patches the issue <https://github.com/zmughal/perl-Gtk3/issues/1>.